### PR TITLE
Remove PDF references from frontend and backend

### DIFF
--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS books (
   description TEXT NOT NULL,
   cover_image VARCHAR(500) NOT NULL,
   ebook_file VARCHAR(500) NOT NULL,
-  file_format VARCHAR(10) NOT NULL CHECK (file_format IN ('pdf', 'epub')),
+  file_format VARCHAR(10) NOT NULL CHECK (file_format IN ('epub', 'mobi', 'azw3')),
   categories TEXT[] NOT NULL,
   average_rating NUMERIC(3, 2) DEFAULT 0,
   total_ratings INTEGER DEFAULT 0,

--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -12,8 +12,8 @@ const upload = multer({
         return cb(new Error('Only image files are allowed!'), false);
       }
     } else if (file.fieldname === "ebook") {
-      if (!file.originalname.match(/\.(pdf|epub)$/i)) {
-        return cb(new Error('Only PDF and EPUB files are allowed!'), false);
+      if (!file.originalname.match(/\.(epub|mobi|azw3)$/i)) {
+        return cb(new Error('Only EPUB, MOBI, and AZW3 eBook formats are allowed!'), false);
       }
     }
     cb(null, true);

--- a/backend/models/Book.js
+++ b/backend/models/Book.js
@@ -23,7 +23,7 @@ const BookSchema = new mongoose.Schema({
   },
   fileFormat: {
     type: String,
-    enum: ['pdf', 'epub'],
+    enum: ['epub', 'mobi', 'azw3'],
     required: true
   },
   categories: [{

--- a/backend/routes/books.js
+++ b/backend/routes/books.js
@@ -10,8 +10,9 @@ const LoggingService = require('../services/loggingService');
 // Helper: derive file format from file extension
 function getFileFormat(fileName) {
   const lower = fileName.toLowerCase();
-  if (lower.endsWith('.pdf')) return 'pdf';
   if (lower.endsWith('.epub')) return 'epub';
+  if (lower.endsWith('.mobi')) return 'mobi';
+  if (lower.endsWith('.azw3')) return 'azw3';
   return null;
 }
 
@@ -82,7 +83,7 @@ router.post('/', [auth, upload.fields([
 
     const fileFormat = getFileFormat(req.files['ebook'][0].originalname);
     if (!fileFormat) {
-      return res.status(400).json({ error: 'Unsupported ebook file format. Only PDF and EPUB are allowed.' });
+      return res.status(400).json({ error: 'Unsupported ebook file format. Only EPUB, MOBI, and AZW3 are allowed.' });
     }
 
     // Upload cover image to Supabase Storage
@@ -211,7 +212,7 @@ router.put('/:id', [auth, upload.fields([
     if (req.files && req.files['ebook']) {
       const fileFormat = getFileFormat(req.files['ebook'][0].originalname);
       if (!fileFormat) {
-        return res.status(400).json({ error: 'Unsupported ebook file format. Only PDF and EPUB are allowed.' });
+        return res.status(400).json({ error: 'Unsupported ebook file format. Only EPUB, MOBI, and AZW3 are allowed.' });
       }
       // Delete old ebook if it exists
       if (book.ebook_file) {

--- a/backend/routes/contributions.js
+++ b/backend/routes/contributions.js
@@ -11,8 +11,9 @@ const LoggingService = require('../services/loggingService');
 // Helper: derive file format from file name
 function getFileFormat(fileName) {
   const lower = fileName.toLowerCase();
-  if (lower.endsWith('.pdf')) return 'pdf';
   if (lower.endsWith('.epub')) return 'epub';
+  if (lower.endsWith('.mobi')) return 'mobi';
+  if (lower.endsWith('.azw3')) return 'azw3';
   return null;
 }
 
@@ -54,7 +55,7 @@ router.post(
       const fileFormat = getFileFormat(req.files.ebook[0].originalname);
       
       if (!fileFormat) {
-        return res.status(400).json({ error: 'Unsupported ebook file format. Only PDF and EPUB are allowed.' });
+        return res.status(400).json({ error: 'Unsupported ebook file format. Only EPUB, MOBI, and AZW3 are allowed.' });
       }
 
       // Upload cover image to Supabase Storage

--- a/backend/routes/contributions.js
+++ b/backend/routes/contributions.js
@@ -98,9 +98,7 @@ router.post(
       }
 
       res.json({
-        message: trackAsContribution 
-          ? 'Thank you for your contribution!' 
-          : 'Book uploaded successfully!',
+        message: 'Thank you for your contribution!',
         contribution: contribution ? {
           id: contribution.id,
           bookId: newBook.id,

--- a/backend/services/storageService.js
+++ b/backend/services/storageService.js
@@ -88,8 +88,9 @@ async function deleteFile(fileUrl, fileType) {
  */
 function getContentType(ext) {
   const mimeTypes = {
-    '.pdf': 'application/pdf',
     '.epub': 'application/epub+zip',
+    '.mobi': 'application/x-mobipocket-ebook',
+    '.azw3': 'application/vnd.amazon.ebook',
     '.jpg': 'image/jpeg',
     '.jpeg': 'image/jpeg',
     '.png': 'image/png',

--- a/backend/services/storageService.js
+++ b/backend/services/storageService.js
@@ -83,7 +83,7 @@ async function deleteFile(fileUrl, fileType) {
 
 /**
  * Get content type based on file extension
- * @param {string} ext - File extension (e.g., '.pdf')
+ * @param {string} ext - File extension (e.g., '.epub', '.mobi', '.azw3')
  * @returns {string} - MIME type
  */
 function getContentType(ext) {
@@ -123,7 +123,7 @@ async function ensureBucketsExist() {
         console.log(`Bucket ${bucketName} not found, creating...`);
         const { data, error: createError } = await supabase.storage.createBucket(bucketName, {
           public: true,
-          allowedMimeTypes: ['image/*', 'application/pdf', 'application/epub+zip']
+          allowedMimeTypes: ['image/*', 'application/epub+zip', 'application/x-mobipocket-ebook', 'application/vnd.amazon.ebook']
         });
         
         if (createError) {

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -473,13 +473,13 @@ const UploadModal = ({ isOpen, onClose, onSuccess }: UploadModalProps) => {
 
           {/* eBook File */}
           <div style={formGroupStyles}>
-            <label style={labelStyles}>eBook File (PDF or EPUB) *</label>
+            <label style={labelStyles}>eBook File (EPUB, MOBI, or AZW3) *</label>
             <div style={uploadAreaStyles(false)}>
               <input
                 type="file"
                 id="ebook-input"
                 style={{ display: "none" }}
-                accept=".pdf,.epub"
+                accept=".epub,.mobi,.azw3"
                 onChange={(e) => handleFileChange(e, "ebook")}
                 disabled={isLoading}
               />

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -74,10 +74,15 @@ const UploadModal = ({ isOpen, onClose, onSuccess }: UploadModalProps) => {
           return;
         }
       } else if (fileType === "ebook") {
-        if (!["application/pdf", "application/epub+zip"].includes(file.type)) {
+        const validMimeTypes = ["application/epub+zip", "application/x-mobipocket-ebook", "application/vnd.amazon.ebook"];
+        const fileName = file.name.toLowerCase();
+        const validExtensions = [".epub", ".mobi", ".azw3"];
+        const hasValidExtension = validExtensions.some(ext => fileName.endsWith(ext));
+        
+        if (!validMimeTypes.includes(file.type) && !hasValidExtension) {
           setMessage({
             type: "error",
-            text: "eBook must be a PDF or EPUB file",
+            text: "eBook must be EPUB, MOBI, or AZW3 format",
           });
           return;
         }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -444,7 +444,7 @@ const Home = () => {
               Multiple Formats
             </h3>
             <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
-              Support for EPUB, PDF, MOBI, and more. Import your entire library
+              Support for EPUB, MOBI, AZW3, and more. Import your entire library
               without format concerns.
             </p>
           </div>

--- a/frontend/src/pages/Library.tsx
+++ b/frontend/src/pages/Library.tsx
@@ -134,7 +134,7 @@ const Library = () => {
           title: book.title || "Unknown",
           author: book.author || "Unknown",
           cover: coverUrl,
-          format: (book.file_format || "pdf").toUpperCase(),
+          format: (book.file_format || "epub").toUpperCase(),
           description: book.description || "",
           categories: book.categories || [],
           rating: book.average_rating || 0,

--- a/frontend/src/services/bookService.ts
+++ b/frontend/src/services/bookService.ts
@@ -94,7 +94,7 @@ export const bookService = {
       : "https://covers.openlibrary.org/b/id/12860656-L.jpg";
 
     const bookId = book._id || book.id || "";
-    const fileFormat = book.file_format || book.fileFormat || "pdf";
+    const fileFormat = book.file_format || book.fileFormat || "epub";
     const averageRating = book.average_rating || book.averageRating || 0;
 
     return {


### PR DESCRIPTION
This pull request updates the supported eBook formats across the backend and frontend, removing PDF support and adding MOBI and AZW3 formats alongside EPUB. The changes ensure consistency in validation, database schema, file handling, and user interface messaging for the new set of supported formats.

**Backend: Supported eBook formats update**

* Database schema (`backend/db/schema.sql`): Changed `file_format` constraint to allow only 'epub', 'mobi', and 'azw3' (removing 'pdf').
* Mongoose model (`backend/models/Book.js`): Updated `fileFormat` enum to match the new allowed formats.
* File upload middleware (`backend/middleware/upload.js`): Now only accepts `.epub`, `.mobi`, and `.azw3` files for eBooks, with error messages updated accordingly.
* Book and contribution routes (`backend/routes/books.js`, `backend/routes/contributions.js`): Updated file format detection and error messages to reflect the new supported formats; removed PDF handling. [[1]](diffhunk://#diff-0c1358feb01c02d852f89a1449783f8d2176aadfbaae1ab955fe46d11eb662ceL13-R15) [[2]](diffhunk://#diff-0c1358feb01c02d852f89a1449783f8d2176aadfbaae1ab955fe46d11eb662ceL85-R86) [[3]](diffhunk://#diff-0c1358feb01c02d852f89a1449783f8d2176aadfbaae1ab955fe46d11eb662ceL214-R215) [[4]](diffhunk://#diff-38ffe6269ca8087a1cb585839c9fd5f579d3bed4edd422e8372baeff43b3a1c5L14-R16) [[5]](diffhunk://#diff-38ffe6269ca8087a1cb585839c9fd5f579d3bed4edd422e8372baeff43b3a1c5L57-R58)
* Storage service (`backend/services/storageService.js`): Updated MIME type detection and allowed MIME types in bucket creation to only include the new formats. [[1]](diffhunk://#diff-941e91df04c347b12772d188d1d475e615dfec2789694788cbd3cb09525f70a8L86-R93) [[2]](diffhunk://#diff-941e91df04c347b12772d188d1d475e615dfec2789694788cbd3cb09525f70a8L125-R126)

**Frontend: UI and validation updates**

* Upload modal (`frontend/src/components/UploadModal.tsx`): Updated validation logic, accepted file extensions, and user-facing labels/messages to match new allowed formats. [[1]](diffhunk://#diff-7845aa8318cae311a03ebff659c5384649a60663eeaf09fc80b7a6ec67301f4aL77-R85) [[2]](diffhunk://#diff-7845aa8318cae311a03ebff659c5384649a60663eeaf09fc80b7a6ec67301f4aL471-R482)
* Home page (`frontend/src/pages/Home.tsx`): Updated feature description to list only EPUB, MOBI, and AZW3 as supported formats.
* Library and book service (`frontend/src/pages/Library.tsx`, `frontend/src/services/bookService.ts`): Changed default file format handling from 'pdf' to 'epub' for consistency with new backend defaults. [[1]](diffhunk://#diff-0ff0f2c44d655037a0febf0af7637de593d71a7b6ebd1e35e25d957c99d2f37fL137-R137) [[2]](diffhunk://#diff-ebc50aec90a26c80abd380f2c8460c564c29fe36ab005cbe1b3cb7a0ba508569L97-R97)

**Other improvements**

* Contribution route (`backend/routes/contributions.js`): Standardized the success message for contributions.